### PR TITLE
Spec path should be relative to script path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 dist
+.DS_Store

--- a/script/cycle.yaml
+++ b/script/cycle.yaml
@@ -1,5 +1,5 @@
 specs: 
-  service: spec/nuxeo.yaml
+  service: ../spec/nuxeo.yaml
 operations:
   taskList:
     operationId: service.taskList

--- a/script/microservices.yaml
+++ b/script/microservices.yaml
@@ -1,7 +1,7 @@
 specs: 
-  serviceA: spec/microservices/petstore-serviceA.yaml
-  serviceB: spec/microservices/petstore-serviceB.yaml
-  serviceC: spec/microservices/petstore-serviceC.yaml
+  serviceA: ../spec/microservices/petstore-serviceA.yaml
+  serviceB: ../spec/microservices/petstore-serviceB.yaml
+  serviceC: ../spec/microservices/petstore-serviceC.yaml
 operations:
   listPets:
     operationId: serviceA.findPetsByStatus

--- a/script/noosa/createPayment.yaml
+++ b/script/noosa/createPayment.yaml
@@ -1,5 +1,5 @@
 specs: 
-  service: spec/noosa.yaml
+  service: ../spec/noosa.yaml
 operations:
 
   pinLogin:

--- a/script/noosa/credit-checked-2.yaml
+++ b/script/noosa/credit-checked-2.yaml
@@ -1,5 +1,5 @@
 specs:
-  API: spec/noosa.yaml
+  API: ../spec/noosa.yaml
 
 security:
   ConsumerAuth:

--- a/script/noosa/credit-checked-parallel.yaml
+++ b/script/noosa/credit-checked-parallel.yaml
@@ -1,4 +1,4 @@
-spec: spec/noosa.yaml
+spec: ../spec/noosa.yaml
 operations:
   
   pinLogin:

--- a/script/noosa/credit-checked.yaml
+++ b/script/noosa/credit-checked.yaml
@@ -1,5 +1,5 @@
 specs: 
-  service: spec/noosa.yaml
+  service: ../spec/noosa.yaml
 operations:
   
   pinLogin:

--- a/script/noosa/credit.yaml
+++ b/script/noosa/credit.yaml
@@ -1,5 +1,5 @@
 specs: 
-  service: spec/noosa.yaml
+  service: ../spec/noosa.yaml
 operations:
   
   pinLogin:

--- a/script/noosa/parallel.yaml
+++ b/script/noosa/parallel.yaml
@@ -1,4 +1,4 @@
-spec: spec/noosa.yaml
+spec: ../spec/noosa.yaml
 operations:
   
   pinLogin1:

--- a/script/noosa/test.yaml
+++ b/script/noosa/test.yaml
@@ -1,5 +1,5 @@
 specs: 
-  service: spec/noosa.yaml
+  service: ../spec/noosa.yaml
 operations:
   pinLogin:
     operationId: service.consumer.pinLogin

--- a/script/nuxeo.yaml
+++ b/script/nuxeo.yaml
@@ -1,5 +1,5 @@
 specs: 
-  service: spec/nuxeo.yaml
+  service: ../spec/nuxeo.yaml
 operations:
   taskList:
     operationId: service.taskList

--- a/script/petstore.yaml
+++ b/script/petstore.yaml
@@ -1,5 +1,5 @@
 specs: 
-  service: spec/petstore.yaml 
+  service: ../spec/petstore.yaml
 operations:
   listPets:
     operationId: service.findPetsByStatus

--- a/src/test/script/Loader.go
+++ b/src/test/script/Loader.go
@@ -2,6 +2,7 @@ package script
 
 import (
 	"io/ioutil"
+	"path/filepath"
 
 	"github.com/go-yaml/yaml"
 	"github.com/x1n13y84issmd42/oasis/src/api"
@@ -26,7 +27,8 @@ func Load(path string, log contract.Logger) contract.Script {
 	specs := make(map[string]contract.OperationAccess)
 
 	for k, v := range script.SpecPaths {
-		spec := utility.Load(v, script.Log)
+		specPath, _ := filepath.Abs(filepath.Join("script", v))
+		spec := utility.Load(specPath, script.Log)
 		specs[k] = spec
 	}
 


### PR DESCRIPTION
- made spec path relative to script path for Script mode 
- added DS_Store to .gitignore (Mac OS metadata files)

Cases:

1) spec is located in oasis/spec folder 
    _home/user/go/src/github.com/username/oasis/spec/petstore.yaml_
    
      specs: 
         service: ../spec/petstore.yaml
          
2) spec is located outside oasis folder
    _home/user/spec/petstore.yaml_
    
     specs: 
         service: ../../../../../../spec/petstore.yaml